### PR TITLE
Add ServiceProvider for testing

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,188 +1,40 @@
-import { APP_BASE_URL, SESSION_SECRET, SPOTIFY_CLIENT_ID } from "./env";
-import {
-  audioFeatureRangesSchema,
-  calculateAudioFeatureRanges,
-  filterByAudioFeatureRanges,
-} from "./models";
 import express, { Router } from "express";
 
-import { DatabaseService } from "./services/database";
-import MongoStore from "connect-mongo";
-import { SpotifyService } from "./services/spotify";
 import morgan from "morgan";
-import { parseJsonQuery } from "./lib/schema";
-import session from "express-session";
-import { toPromise } from "./lib/observable";
-import z from "zod";
+import {
+  SignInHandler,
+  SignOutHandler,
+  SpotifyLoginUrlHandler,
+} from "./handlers/auth";
+import {
+  ExportPlaylistHandler,
+  PlaylistDetailHandler,
+  PlaylistsHandler,
+  PlaylistTracksHandler,
+} from "./handlers/playlist";
+import { ProfileHandler } from "./handlers/profile";
+import { ServiceProvider } from "./services";
 
-const databaseService = DatabaseService();
-const spotifyService = SpotifyService(databaseService);
+export function App(service: ServiceProvider = ServiceProvider()) {
+  const app = express();
 
-const app = express();
+  app.use(morgan("short"));
+  app.use(service("session").middleware);
+  app.use(express.json());
 
-app.use(morgan("short"));
-app.use(
-  session({
-    secret: SESSION_SECRET,
-    cookie: {},
-    store: MongoStore.create({
-      clientPromise: databaseService.client$,
-      collectionName: "Session",
-      mongoOptions: {
-        serverSelectionTimeoutMS: 1000,
-      },
-    }),
-    // Firebase hosting strips all cookies except "__session".
-    // https://firebase.google.com/docs/hosting/manage-cache#using_cookies
-    name: "__session",
-  })
-);
-app.use(express.json());
+  const api = Router();
+  app.use("/api", api);
 
-const api = Router();
-app.use("/api", api);
+  api.get("/profile", ProfileHandler(service("database")));
+  api.get("/spotify-login-url", SpotifyLoginUrlHandler());
+  api.get("/signin", SignInHandler(service("spotify")));
+  api.post("/signout", SignOutHandler());
+  api.get("/playlists", PlaylistsHandler(service("spotify")));
+  api.get("/playlists/:id", PlaylistDetailHandler(service("spotify")));
+  api.get("/playlists/:id/tracks", PlaylistTracksHandler(service("spotify")));
+  api.post("/playlists/:id/export", ExportPlaylistHandler(service("spotify")));
 
-api.get("/profile", async (req, res, next) => {
-  if (req.session.uid == null) {
-    return res.sendStatus(403);
-  }
-  try {
-    const profile = await databaseService.getProfile(req.session.uid);
+  return app;
+}
 
-    return res.json({
-      profile,
-    });
-  } catch (err) {
-    return next(err);
-  }
-});
-
-api.get("/spotify-login-url", (req, res) => {
-  const loginUrl =
-    "https://accounts.spotify.com/authorize?" +
-    new URLSearchParams({
-      client_id: SPOTIFY_CLIENT_ID,
-      response_type: "code",
-      redirect_uri: `${APP_BASE_URL}/api/signin`,
-      scope: "playlist-read-private playlist-modify-private",
-    }).toString();
-
-  return res.json({
-    url: loginUrl,
-  });
-});
-
-api.get("/signin", async (req, res, next) => {
-  try {
-    const { code, error } = req.query;
-    if (error) {
-      return res.status(500).send("Failed to login");
-    }
-    if (typeof code !== "string") {
-      return res.status(400).send("No code provided");
-    }
-
-    const uid = await spotifyService.signIn(code);
-    req.session.uid = uid;
-
-    return res.redirect("/");
-  } catch (err) {
-    return next(err);
-  }
-});
-
-api.post("/signout", (req, res, next) => {
-  req.session.destroy((err) => {
-    if (err == null) {
-      res.sendStatus(200);
-    } else {
-      next(err);
-    }
-  });
-});
-
-api.get("/playlists", async (req, res, next) => {
-  if (req.session.uid == null) {
-    return res.sendStatus(403);
-  }
-  try {
-    const playlists = await toPromise(
-      spotifyService.getPlaylists(spotifyService.getValidToken(req.session.uid))
-    );
-
-    return res.json({
-      playlists,
-    });
-  } catch (err) {
-    return next(err);
-  }
-});
-
-api.get("/playlists/:id", async (req, res, next) => {
-  if (req.session.uid == null) {
-    return res.sendStatus(403);
-  }
-  try {
-    const playlist = await spotifyService.getPlaylist(
-      spotifyService.getValidToken(req.session.uid),
-      req.params.id
-    );
-    return res.json({ playlist });
-  } catch (err) {
-    return next(err);
-  }
-});
-
-api.get("/playlists/:id/tracks", async (req, res, next) => {
-  if (req.session.uid == null) {
-    return res.sendStatus(403);
-  }
-  try {
-    const tracks = await toPromise(
-      spotifyService
-        .getTracks(spotifyService.getValidToken(req.session.uid), req.params.id)
-        .pipe(
-          filterByAudioFeatureRanges(
-            parseJsonQuery(
-              req.query.audioFeatureRanges,
-              audioFeatureRangesSchema.nullish()
-            ) ?? {}
-          )
-        )
-    );
-    const audioFeatureRanges = calculateAudioFeatureRanges(tracks);
-    return res.json({
-      tracks,
-      audioFeatureRanges,
-    });
-  } catch (err) {
-    return next(err);
-  }
-});
-
-api.post("/playlists/:id/export", async (req, res, next) => {
-  if (req.session.uid == null) {
-    return res.sendStatus(403);
-  }
-  try {
-    const { playlistName, audioFeatureRanges } = z
-      .object({
-        playlistName: z.string(),
-        audioFeatureRanges: audioFeatureRangesSchema,
-      })
-      .parse(req.body);
-    const playlistId = await spotifyService.exportPlaylist(
-      spotifyService.getValidToken(req.session.uid),
-      req.params.id,
-      playlistName,
-      audioFeatureRanges
-    );
-    return res.json({
-      playlistId,
-    });
-  } catch (err) {
-    return next(err);
-  }
-});
-
-export default app;
+export type App = ReturnType<typeof App>;

--- a/server/src/handlers/auth.ts
+++ b/server/src/handlers/auth.ts
@@ -1,0 +1,50 @@
+import { RequestHandler } from "express";
+import { APP_BASE_URL, SPOTIFY_CLIENT_ID } from "../env";
+import { SpotifyService } from "../services/spotify";
+
+export const SpotifyLoginUrlHandler =
+  (): RequestHandler => async (req, res, next) => {
+    const loginUrl =
+      "https://accounts.spotify.com/authorize?" +
+      new URLSearchParams({
+        client_id: SPOTIFY_CLIENT_ID,
+        response_type: "code",
+        redirect_uri: `${APP_BASE_URL}/api/signin`,
+        scope: "playlist-read-private playlist-modify-private",
+      }).toString();
+
+    return res.json({
+      url: loginUrl,
+    });
+  };
+
+export const SignInHandler =
+  (spotify: SpotifyService): RequestHandler =>
+  async (req, res, next) => {
+    try {
+      const { code, error } = req.query;
+      if (error) {
+        return res.status(500).send("Failed to login");
+      }
+      if (typeof code !== "string") {
+        return res.status(400).send("No code provided");
+      }
+
+      const uid = await spotify.signIn(code);
+      req.session.uid = uid;
+
+      return res.redirect("/");
+    } catch (err) {
+      return next(err);
+    }
+  };
+
+export const SignOutHandler = (): RequestHandler => async (req, res, next) => {
+  req.session.destroy((err) => {
+    if (err == null) {
+      res.sendStatus(200);
+    } else {
+      next(err);
+    }
+  });
+};

--- a/server/src/handlers/playlist.ts
+++ b/server/src/handlers/playlist.ts
@@ -1,0 +1,108 @@
+import { RequestHandler } from "express";
+import invariant from "tiny-invariant";
+import { z } from "zod";
+import { toPromise } from "../lib/observable";
+import { parseJsonQuery } from "../lib/schema";
+import {
+  audioFeatureRangesSchema,
+  calculateAudioFeatureRanges,
+  filterByAudioFeatureRanges,
+} from "../models";
+import { SpotifyService } from "../services/spotify";
+
+export const PlaylistsHandler =
+  (spotify: SpotifyService): RequestHandler =>
+  async (req, res, next) => {
+    if (req.session.uid == null) {
+      return res.sendStatus(403);
+    }
+    try {
+      const playlists = await toPromise(
+        spotify.getPlaylists(spotify.getValidToken(req.session.uid))
+      );
+
+      return res.json({
+        playlists,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  };
+export const PlaylistDetailHandler =
+  (spotify: SpotifyService): RequestHandler =>
+  async (req, res, next) => {
+    if (req.session.uid == null) {
+      return res.sendStatus(403);
+    }
+    try {
+      const { id } = req.params;
+      invariant(id);
+      const playlist = await spotify.getPlaylist(
+        spotify.getValidToken(req.session.uid),
+        id
+      );
+      return res.json({ playlist });
+    } catch (err) {
+      return next(err);
+    }
+  };
+
+export const PlaylistTracksHandler =
+  (spotify: SpotifyService): RequestHandler =>
+  async (req, res, next) => {
+    if (req.session.uid == null) {
+      return res.sendStatus(403);
+    }
+    try {
+      const { id } = req.params;
+      invariant(id);
+      const tracks = await toPromise(
+        spotify
+          .getTracks(spotify.getValidToken(req.session.uid), id)
+          .pipe(
+            filterByAudioFeatureRanges(
+              parseJsonQuery(
+                req.query.audioFeatureRanges,
+                audioFeatureRangesSchema.nullish()
+              ) ?? {}
+            )
+          )
+      );
+      const audioFeatureRanges = calculateAudioFeatureRanges(tracks);
+      return res.json({
+        tracks,
+        audioFeatureRanges,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  };
+
+export const ExportPlaylistHandler =
+  (spotify: SpotifyService): RequestHandler =>
+  async (req, res, next) => {
+    if (req.session.uid == null) {
+      return res.sendStatus(403);
+    }
+    try {
+      const { id } = req.params;
+      invariant(id);
+      const { playlistName, audioFeatureRanges } = z
+        .object({
+          playlistName: z.string(),
+          audioFeatureRanges: audioFeatureRangesSchema,
+        })
+        .parse(req.body);
+      const playlistId = await spotify.exportPlaylist(
+        spotify.getValidToken(req.session.uid),
+        id,
+        playlistName,
+        audioFeatureRanges
+      );
+      return res.json({
+        playlistId,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  };

--- a/server/src/handlers/profile.ts
+++ b/server/src/handlers/profile.ts
@@ -1,0 +1,19 @@
+import { RequestHandler } from "express";
+import { DatabaseService } from "../services/database";
+
+export const ProfileHandler =
+  (database: DatabaseService): RequestHandler =>
+  async (req, res, next) => {
+    if (req.session.uid == null) {
+      return res.sendStatus(403);
+    }
+    try {
+      const profile = await database.getProfile(req.session.uid);
+
+      return res.json({
+        profile,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,6 @@
+import { App } from "./app";
 import { PORT } from "./env";
-import app from "./app";
 
-app.listen(PORT, () => {
+App().listen(PORT, () => {
   console.log(`API server listening to ${PORT}...`);
 });

--- a/server/src/services/database/index.ts
+++ b/server/src/services/database/index.ts
@@ -14,7 +14,7 @@ export const DatabaseService = () => {
     });
 
   return {
-    client$,
+    getClient: () => client$,
     getAuthDoc: async (uid: string) => {
       const authDoc = await SpotifyAuth.findById(uid);
       return authDoc?.toObject();

--- a/server/src/services/database/mock.ts
+++ b/server/src/services/database/mock.ts
@@ -1,0 +1,13 @@
+import { DatabaseService } from ".";
+
+export default function MockDatabaseService(): jest.Mocked<DatabaseService> {
+  return {
+    getClient: jest.fn(),
+    createAuthDoc: jest.fn(),
+    getAudioFeaturesCache: jest.fn(),
+    getAuthDoc: jest.fn(),
+    getProfile: jest.fn(),
+    setAudioFeaturesCache: jest.fn(),
+    updateAuthDoc: jest.fn(),
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,0 +1,37 @@
+import { DatabaseService } from "./database";
+import { SessionService } from "./session";
+import { SpotifyService } from "./spotify";
+
+type ServiceMap = {
+  database: DatabaseService;
+  spotify: SpotifyService;
+  session: SessionService;
+};
+
+/**
+ * Central place holding all available services.
+ * @param override For testing. Replace actual services with fake services during testing.
+ * @returns `getService` function for accessing services.
+ */
+export const ServiceProvider = (override?: Partial<ServiceMap>) => {
+  const database = override?.database ?? DatabaseService();
+  const spotify = override?.spotify ?? SpotifyService(database);
+  const session = override?.session ?? SessionService(database);
+
+  const serviceMap: ServiceMap = {
+    database,
+    spotify,
+    session,
+  };
+
+  /**
+   * Get service by service name.
+   */
+  const getService = <TServiceName extends keyof ServiceMap>(
+    serviceName: TServiceName
+  ) => serviceMap[serviceName];
+
+  return getService;
+};
+
+export type ServiceProvider = ReturnType<typeof ServiceProvider>;

--- a/server/src/services/session/index.ts
+++ b/server/src/services/session/index.ts
@@ -1,0 +1,25 @@
+import { DatabaseService } from "../../services/database";
+import MongoStore from "connect-mongo";
+import { SESSION_SECRET } from "../../env";
+import session from "express-session";
+
+export const SessionService = (databaseService: DatabaseService) => {
+  return {
+    middleware: session({
+      secret: SESSION_SECRET,
+      cookie: {},
+      store: MongoStore.create({
+        clientPromise: databaseService.getClient(),
+        collectionName: "Session",
+        mongoOptions: {
+          serverSelectionTimeoutMS: 1000,
+        },
+      }),
+      // Firebase hosting strips all cookies except "__session".
+      // https://firebase.google.com/docs/hosting/manage-cache#using_cookies
+      name: "__session",
+    }),
+  };
+};
+
+export type SessionService = ReturnType<typeof SessionService>;

--- a/server/src/services/session/mock.ts
+++ b/server/src/services/session/mock.ts
@@ -1,0 +1,20 @@
+import { RequestHandler } from "express";
+import { SessionData } from "express-session";
+import { SessionService } from ".";
+
+export const MockSessionService = (): jest.Mocked<SessionService> => {
+  return {
+    middleware: jest.fn().mockImplementation(
+      MockSessionMiddleware({
+        uid: "TEST_UID",
+      })
+    ),
+  };
+};
+
+export const MockSessionMiddleware =
+  (data: Partial<SessionData>): RequestHandler =>
+  (req, res, next) => {
+    req.session = Object.assign(req.session ?? {}, data);
+    next();
+  };


### PR DESCRIPTION
#### Changes
- Change `app.ts` to return a factory function `App()` instead of directly returning `app`. This makes testing easier. For example, we can do `const app = App()` for production while doing `const testApp = App(ServiceProvider({ database: mockDatabase }))` for testing.
- Extract request handlers into separate functions under `handlers` directory.
- Extract session middleware into a service.
- Add more test cases to `api.test.ts`