### PR TITLE
Fix Argos CI screenshot path

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "typecheck:watch": "tsc --watch",
     "build": "pnpm typecheck && vite build",
     "test": "cypress run --component",
-    "argos:upload": "argos upload screenshots"
+    "argos:upload": "argos upload cypress/screenshots"
   },
   "dependencies": {
     "@tanstack/react-query": "^4.0.10",


### PR DESCRIPTION
Screenshots are stored under `app/cypress/screenshots`. Fix the path in `app/package.json`.