### PR TITLE
Setup dark mode testing

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <script src="/darkmode.js"></script>
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/app/public/darkmode.js
+++ b/app/public/darkmode.js
@@ -1,0 +1,5 @@
+// Add "dark" class to document before page load if the user prefers dark mode.
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+if (prefersDark) {
+  document.documentElement.classList.add("dark");
+}

--- a/app/src/components/Button.cy.tsx
+++ b/app/src/components/Button.cy.tsx
@@ -6,7 +6,25 @@ it("default", function () {
   cy.argosScreenshot(Cypress.currentTest.title);
 });
 
+it("dark", () => {
+  mount(
+    <div className="dark">
+      <Button>button</Button>
+    </div>
+  );
+  cy.argosScreenshot(Cypress.currentTest.title);
+});
+
 it("primary", function () {
   mount(<Button variant="primary">Primary</Button>);
+  cy.argosScreenshot(Cypress.currentTest.title);
+});
+
+it("dark primary", () => {
+  mount(
+    <div className="dark">
+      <Button variant="primary">button</Button>
+    </div>
+  );
   cy.argosScreenshot(Cypress.currentTest.title);
 });

--- a/app/src/components/MinMaxSlider.cy.tsx
+++ b/app/src/components/MinMaxSlider.cy.tsx
@@ -20,6 +20,26 @@ it("0-1", function () {
   cy.argosScreenshot(Cypress.currentTest.title);
 });
 
+it("dark 0-1", function () {
+  const sliderMin = 0;
+  const sliderMax = 1;
+  const minInputAtom = atom(sliderMin);
+  const maxInputAtom = atom(sliderMax);
+
+  mount(
+    <div className="dark">
+      <MinMaxSlider
+        sliderMin={sliderMin}
+        sliderMax={sliderMax}
+        minInputAtom={minInputAtom}
+        maxInputAtom={maxInputAtom}
+      />
+    </div>
+  );
+
+  cy.argosScreenshot(Cypress.currentTest.title);
+});
+
 it("30-120", function () {
   const sliderMin = 30;
   const sliderMax = 120;

--- a/app/src/pages/SignIn.cy.tsx
+++ b/app/src/pages/SignIn.cy.tsx
@@ -22,3 +22,22 @@ it("default", () => {
   );
   cy.argosScreenshot(Cypress.currentTest.title);
 });
+
+it("dark", () => {
+  worker.use(
+    rest.get("/api/profile", (req, res, ctx) => {
+      return res(ctx.status(403));
+    })
+  );
+
+  mount(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <div className="dark">
+          <SignIn />
+        </div>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+  cy.argosScreenshot(Cypress.currentTest.title);
+});

--- a/app/src/sprinkles.css.ts
+++ b/app/src/sprinkles.css.ts
@@ -72,7 +72,9 @@ const responsiveProperties = defineProperties({
 const colorProperties = defineProperties({
   conditions: {
     lightMode: {},
-    darkMode: { "@media": "(prefers-color-scheme: dark)" },
+    darkMode: {
+      selector: ".dark &",
+    },
   },
   defaultCondition: "lightMode",
   properties: {

--- a/app/src/theme.css.ts
+++ b/app/src/theme.css.ts
@@ -112,13 +112,11 @@ globalStyle("html", {
   background: vars.palette.slate100,
   color: vars.palette.slate900,
   fontFamily: vars.font.brand,
+});
 
-  "@media": {
-    "(prefers-color-scheme: dark)": {
-      background: vars.palette.zinc800,
-      color: vars.palette.zinc100,
-    },
-  },
+globalStyle(".dark", {
+  background: vars.palette.zinc800,
+  color: vars.palette.zinc100,
 });
 
 globalStyle("a", {


### PR DESCRIPTION
#### Changes
- Put dark styles in `.dark` selector instead of dark mode media query.
- Add a tiny script for automatically adding `dark` class to HTML on load.
- Test components with dark mode styles.