### PR TITLE
Handle expired refresh token

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import {
   SignInHandler,
   SignOutHandler,
   SpotifyLoginUrlHandler,
+  SpotifyTokenErrorHandler,
 } from "./handlers/auth";
 import {
   ExportPlaylistHandler,
@@ -33,6 +34,7 @@ export function App(service: ServiceProvider) {
   api.get("/playlists/:id", PlaylistDetailHandler(service("spotify")));
   api.get("/playlists/:id/tracks", PlaylistTracksHandler(service("spotify")));
   api.post("/playlists/:id/export", ExportPlaylistHandler(service("spotify")));
+  api.use(SpotifyTokenErrorHandler());
 
   return app;
 }


### PR DESCRIPTION
#### Problem
Infinite redirection loop between login & home pages.

#### Breakdown
Given expired refresh token:
- Login page redirects to home page because GET /api/profile is successful (doesn't involve any Spotify API calls).
- Home page redirects to login page because GET /api/playlists fails due to expired refresh token.

#### Changes
Destroy session when Spotify token cannot be obtained. New access token & refresh token will be issued
when user re-authenticates.